### PR TITLE
fix(stale): never auto-close — label only (days-before-close: -1)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,26 +22,26 @@ jobs:
           # Issue configuration
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 7 days if no further activity occurs.
+            recent activity. It will remain open — this label is informational only; this project never auto-closes.
             If this issue is still relevant, please comment or update it to keep it open.
           close-issue-message: >
             This issue was closed because it has been stale for 7 days with no activity.
             Feel free to reopen if this is still relevant.
           stale-issue-label: 'stale'
           days-before-issue-stale: 30
-          days-before-issue-close: 7
+          days-before-issue-close: -1
 
           # PR configuration
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
+            recent activity. It will remain open — this label is informational only; this project never auto-closes.
             If this PR is still relevant, please update it or request a review.
           close-pr-message: >
             This PR was closed because it has been stale for 14 days with no activity.
             Feel free to reopen if this is still relevant.
           stale-pr-label: 'stale'
           days-before-pr-stale: 30
-          days-before-pr-close: 14
+          days-before-pr-close: -1
 
           # Exempt labels (these issues/PRs won't be marked stale)
           exempt-issue-labels: 'pinned,security,in-progress,help wanted,good first issue'


### PR DESCRIPTION
The stale workflow auto-closed issues/PRs, violating this universe's absolute doctrine: **we never close, dismiss, or delete** — *if it was ever asked for it was wanted*.

This sets the close window to `-1` (`actions/stale` never-close), preserving the informational `stale` label but never closing. Surgical, reversible, single-file.