### PR TITLE
fix: contain top color-band clip + clean bottom back-button strip

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -938,6 +938,36 @@ footer {
   height: 5rem;
 }
 
+/* Back button — a labeled control, not a stray return-arrow glyph */
+#backButtonContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#backButton.black-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.85rem;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  border-radius: 999px;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.backButton__glyph {
+  font-size: 1.5rem;
+  line-height: 1;
+  transform: translateY(-0.05em);
+}
+
+.backButton__label {
+  font-size: 0.9rem;
+  font-weight: normal;
+}
+
 .audioPlayer {
   max-width: 22rem;
   min-width: 13rem;

--- a/index.html
+++ b/index.html
@@ -77,7 +77,10 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   </head>
 
-  <body class="min-vh-100 w-100 futura fw1" style="background-image: url(img/web-bg2.gif)">
+  <body
+    class="min-vh-100 w-100 futura fw1"
+    style="background-color: #c0361e; background-image: url(img/web-bg2.gif); background-size: cover; background-position: center; background-repeat: no-repeat; background-attachment: fixed"
+  >
     <!-- Skip to main content link for accessibility -->
     <a href="#pages" class="skip-link" aria-label="Skip to main content">Skip to main content</a>
 
@@ -779,8 +782,11 @@
         </section>
 
         <!-- Back Button -->
-        <section id="backButtonContainer" class="backButtonContainer mw2 tc">
-          <a id="backButton" href="#" class="black-link f-2_0625rem link">&#8629;</a>
+        <section id="backButtonContainer" class="backButtonContainer tc">
+          <a id="backButton" href="#" class="black-link link" aria-label="Go back">
+            <span class="backButton__glyph" aria-hidden="true">&#8629;</span>
+            <span class="backButton__label">BACK</span>
+          </a>
         </section>
 
         <!-- Support Us / Site Map / Mailing List -->


### PR DESCRIPTION
Re-diagnosis of #109 which targeted the wrong element (`#landingPageCanvasWrapper`).

## Actual root causes (diagnosed against the deployed page)

1. **Top pink/lavender/beige bands** — the `<body>` background is `img/web-bg2.gif`, a 2000x2000 grid of pink/lavender/beige/purple color blocks with `background-color: transparent` and `background-repeat: repeat`. The orange landing hero is a WebGL canvas at `z-index:-1`; a seam at the top let the raw pink gif tiles show through as clipped horizontal bands. Fixed by giving the body a solid orange base (`#c0361e`, matching the hero) plus `background-size: cover; background-repeat: no-repeat; background-attachment: fixed` so any seam shows hero orange, never raw pink tiles.

2. **Bare return-arrow glyph** — the footer `#backButton` was a lone `↵` (`&#8629;`) on a white strip, reading as a broken artifact. Restyled as a labeled, pill-shaped "BACK" control with an aria-hidden glyph; navigation (`href="#"`) is unchanged.

Verified against the deployed page.

🤖 Generated with Claude Code