### PR TITLE
fix(hero): remove tiled gif that clipped as color bands above the hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
 
   <body
     class="min-vh-100 w-100 futura fw1"
-    style="background-color: #c0361e; background-image: url(img/web-bg2.gif); background-size: cover; background-position: center; background-repeat: no-repeat; background-attachment: fixed"
+    style="background-color: #c0361e"
   >
     <!-- Skip to main content link for accessibility -->
     <a href="#pages" class="skip-link" aria-label="Skip to main content">Skip to main content</a>


### PR DESCRIPTION
The body `background-image: url(img/web-bg2.gif)` (a grid of colored blocks) showed through the strip above the fixed WebGL hero canvas, rendering as clipped pink/lavender/yellow-green bands at the very top (DECORVM visual finding). Removed the gif from the body inline style, keeping the solid `#c0361e` hero orange so the top strip matches the hero. Sibling to #110 (which fixed the ↵ BACK glyph).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the page background to use a solid red color.
  * Removed the previous background image and related positioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->